### PR TITLE
Update zabbix_agentd.conf

### DIFF
--- a/install/zabbix/zabbix_agentd.conf
+++ b/install/zabbix/zabbix_agentd.conf
@@ -7,7 +7,12 @@ ListenPort=10050
 StartAgents=5
 DebugLevel=3
 PidFile=/run/zabbix/zabbix_agentd.pid
-LogFile=/var/log/zabbix/zabbix_agentd.log
+### Descomentar logs según corresponda
+# Version 5.4 o anteriores.
+#LogFile=/var/log/zabbix/zabbix_agentd.log
+# Version 6.4 o posteriores
+LogFile=/var/log/zabbix-agent/zabbix_agentd.log
+
 LogFileSize=1
 Timeout=10
 


### PR DESCRIPTION
De la versión 6 en adelante, Zabbix cambio el directorio de logs